### PR TITLE
Use consistent indentation in mount-zfs.sh

### DIFF
--- a/dracut/90zfs/mount-zfs.sh
+++ b/dracut/90zfs/mount-zfs.sh
@@ -9,8 +9,8 @@ if [ "$rootfs" = "zfs" ]; then
     mount -o zfsutil -t "$rootfs" "$zfsrootfs" "$NEWROOT"
     if [ "$?" = "0" ]
     then
-	ROOTFS_MOUNTED=yes
+        ROOTFS_MOUNTED=yes
     else
         mount -t "$rootfs" "$zfsrootfs" "$NEWROOT" && ROOTFS_MOUNTED=yes
-   fi
+    fi
 fi


### PR DESCRIPTION
- Fix one instance of mixed tabs/spaces
- Align closing "fi"
