### PR TITLE
Use new -P to get list of zpool devices

### DIFF
--- a/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
+++ b/contrib/dracut/02zfsexpandknowledge/module-setup.sh.in
@@ -17,27 +17,22 @@ get_pool_devices() {
   local prefix
   local resolved
   poolconfigtemp=`mktemp`
-  @sbindir@/zpool list -v -H "$1" > "$poolconfigtemp" 2>&1
+  @sbindir@/zpool list -v -H -P "$1" > "$poolconfigtemp" 2>&1
   if [ "$?" != "0" ] ; then
     poolconfigoutput=$(cat "$poolconfigtemp")
     dinfo "zfsexpandknowledge: pool $1 cannot be listed: $poolconfigoutput"
   else
     while read pooldev ; do
-      for prefix in /dev/sd* /dev/hd* /dev/disk/* /dev/mapper ; do
-        if [ -n "$pooldev" -a -e "$prefix"/"$pooldev" ] ; then
-          if [   -d "$prefix/$pooldev" ] ; then
-              continue
-          elif [ -h "$prefix/$pooldev" ] ; then
-              resolved=`readlink -f "$prefix"/"$pooldev"`
+        if [ -n "$pooldev" -a -e "$pooldev" ] ; then
+          if [ -h "$pooldev" ] ; then
+              resolved=`readlink -f "$pooldev"`
           else
               resolved="$pooldev"
           fi
-          dinfo "zfsexpandknowledge: pool $1 has device $prefix/$pooldev (which resolves to $resolved)"
+          dinfo "zfsexpandknowledge: pool $1 has device $pooldev (which resolves to $resolved)"
           echo "$resolved"
-          break
         fi
-      done
-    done < <(cat "$poolconfigtemp" | awk -F '\t' 'NR>1 { print $2 }')
+    done < <(cat "$poolconfigtemp" |  awk -F '\t' '/\t\/dev/ { print $2 }')
   fi
   rm -f "$poolconfigtemp"
 }


### PR DESCRIPTION
Have adjusted ```get_pool_devices``` to use the ```-P``` switch, here is (with a dodgy stdout dinfo replacement) an example on pool with a mixture (let us know if any idea's for cleanup)

```
# zpool status system
  pool: system
 state: ONLINE
status: Some supported features are not enabled on the pool. The pool can
        still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
        the pool may no longer be accessible by software that does not support
        the features. See zpool-features(5) for details.
  scan: scrub canceled on Sun May  1 17:20:59 2016
config:

        NAME                                                   STATE     READ WRITE CKSUM
        system                                                 ONLINE       0     0     0
          mirror-0                                             ONLINE       0     0     0
            sdh                                                ONLINE       0     0     0
            sdf                                                ONLINE       0     0     0
            sdi                                                ONLINE       0     0     0
        logs
          mirror-1                                             ONLINE       0     0     0
            sdd3                                               ONLINE       0     0     0
            sde3                                               ONLINE       0     0     0
        cache
          ata-Samsung_SSD_840_EVO_120GB_S1D5NSBDA42933Z-part5  ONLINE       0     0     0
          ata-Samsung_SSD_840_EVO_120GB_S1D5NSBDA20279M-part5  ONLINE       0     0     0

errors: No known data errors

# get_pool_devices system
dinfo: zfsexpandknowledge: pool system has device /dev/sdh1 (which resolves to /dev/sdh1)
/dev/sdh1
dinfo: zfsexpandknowledge: pool system has device /dev/sdf1 (which resolves to /dev/sdf1)
/dev/sdf1
dinfo: zfsexpandknowledge: pool system has device /dev/sdi1 (which resolves to /dev/sdi1)
/dev/sdi1
dinfo: zfsexpandknowledge: pool system has device /dev/sdd3 (which resolves to /dev/sdd3)
/dev/sdd3
dinfo: zfsexpandknowledge: pool system has device /dev/sde3 (which resolves to /dev/sde3)
/dev/sde3
dinfo: zfsexpandknowledge: pool system has device /dev/disk/by-id/ata-Samsung_SSD_840_EVO_120GB_S1D5NSBDA42933Z-part5 (which resolves to /dev/sdd5)
/dev/sdd5
dinfo: zfsexpandknowledge: pool system has device /dev/disk/by-id/ata-Samsung_SSD_840_EVO_120GB_S1D5NSBDA20279M-part5 (which resolves to /dev/sde5)
/dev/sde5
```